### PR TITLE
Add method to fetch latest subreddit feed

### DIFF
--- a/src/subreddit/mod.rs
+++ b/src/subreddit/mod.rs
@@ -74,6 +74,11 @@ impl Subreddit {
         // TODO: time filter
         self.get_feed("top", limit)
     }
+
+    /// Get latest posts.
+    pub fn latest(&self, limit: u32) -> Result<Submissions, RouxError> {
+        self.get_feed("new", limit)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
There was not a method to fetch the latest submissions for a sub reddit, so I added one. I named it `latest` instead of `new` because it would conflict with the [new](https://docs.rs/roux/0.2.1/roux/subreddit/struct.Subreddit.html#method.new) method.