### PR TITLE
add me.private_message

### DIFF
--- a/src/me/mod.rs
+++ b/src/me/mod.rs
@@ -5,7 +5,7 @@ use reqwest::{header, Client, Response};
 use serde::Serialize;
 
 use crate::config::Config;
-use crate::util::{RouxError, url};
+use crate::util::{url, RouxError};
 
 mod responses;
 use responses::MeData;
@@ -22,12 +22,12 @@ impl Me {
 
         headers.insert(
             header::AUTHORIZATION,
-            header::HeaderValue::from_str(&format!("Bearer {}", access_token)).unwrap()
+            header::HeaderValue::from_str(&format!("Bearer {}", access_token)).unwrap(),
         );
 
         headers.insert(
             header::USER_AGENT,
-            header::HeaderValue::from_str(&config.user_agent[..]).unwrap()
+            header::HeaderValue::from_str(&config.user_agent[..]).unwrap(),
         );
 
         let client = Client::builder().default_headers(headers).build().unwrap();
@@ -75,6 +75,21 @@ impl Me {
         self.post("api/submit", &form)
     }
 
+    pub fn private_message(
+        &self,
+        username: &str,
+        subject: &str,
+        body: &str,
+    ) -> Result<Response, RouxError> {
+        let form = [
+            ("api_type", "json"),
+            ("subject", subject),
+            ("text", body),
+            ("to", username),
+        ];
+        self.post("api/compose", &form)
+    }
+
     pub fn submit_text(&self, title: &str, text: &str, sr: &str) -> Result<Response, RouxError> {
         let form = [
             ("kind", "self"),
@@ -91,7 +106,8 @@ impl Me {
 
         let form = [("access_token", self.access_token.to_owned())];
 
-        let response = self.client
+        let response = self
+            .client
             .post(url)
             .basic_auth(&self.config.client_id, Some(&self.config.client_secret))
             .form(&form)

--- a/src/subreddit/mod.rs
+++ b/src/subreddit/mod.rs
@@ -19,11 +19,11 @@
 extern crate reqwest;
 extern crate serde_json;
 
-use reqwest::Client;
 use crate::util::RouxError;
+use reqwest::Client;
 
 mod responses;
-use responses::{Moderators, Submissions, Comments};
+use responses::{Comments, Moderators, Submissions};
 
 /// Subreddit.
 pub struct Subreddit {
@@ -47,21 +47,23 @@ impl Subreddit {
 
     /// Get moderators.
     pub fn moderators(&self) -> Result<Moderators, RouxError> {
-        Ok(self.client
+        Ok(self
+            .client
             .get(&format!("{}/about/moderators/.json", self.url))
             .send()?
             .json::<Moderators>()?)
     }
 
     fn get_feed(&self, ty: &str, limit: u32) -> Result<Submissions, RouxError> {
-        Ok(self.client
+        Ok(self
+            .client
             .get(&format!("{}/{}.json?limit={}", self.url, ty, limit))
             .send()?
             .json::<Submissions>()?)
     }
-    
     fn get_comment_feed(&self, ty: &str, limit: u32) -> Result<Comments, RouxError> {
-        Ok(self.client
+        Ok(self
+            .client
             .get(&format!("{}/{}.json?limit={}", self.url, ty, limit))
             .send()?
             .json::<Comments>()?)
@@ -87,7 +89,6 @@ impl Subreddit {
     pub fn latest(&self, limit: u32) -> Result<Submissions, RouxError> {
         self.get_feed("new", limit)
     }
-    
     /// Get latest comments.
     pub fn latest_comments(&self, limit: u32) -> Result<Comments, RouxError> {
         self.get_comment_feed("comments", limit)

--- a/src/subreddit/mod.rs
+++ b/src/subreddit/mod.rs
@@ -23,11 +23,7 @@ use crate::util::RouxError;
 use reqwest::Client;
 
 mod responses;
-<<<<<<< HEAD
 use responses::{Comments, Moderators, Submissions};
-=======
-use responses::{Moderators, Submissions, Comments};
->>>>>>> add get_comment_feed
 
 /// Subreddit.
 pub struct Subreddit {

--- a/src/subreddit/mod.rs
+++ b/src/subreddit/mod.rs
@@ -23,7 +23,11 @@ use crate::util::RouxError;
 use reqwest::Client;
 
 mod responses;
+<<<<<<< HEAD
 use responses::{Comments, Moderators, Submissions};
+=======
+use responses::{Moderators, Submissions, Comments};
+>>>>>>> add get_comment_feed
 
 /// Subreddit.
 pub struct Subreddit {

--- a/src/subreddit/responses/comments.rs
+++ b/src/subreddit/responses/comments.rs
@@ -43,7 +43,11 @@ pub struct CommentsData {
     pub downs: i32,
     pub is_submitter: bool,
     pub body_html: String,
+<<<<<<< HEAD
     pub distinguished: Option<String>,
+=======
+    pub distinguished: Option<bool>,
+>>>>>>> fixed a few that I missed
     pub stickied: bool,
     pub author_premium: bool,
     pub can_gild: bool,

--- a/src/subreddit/responses/comments.rs
+++ b/src/subreddit/responses/comments.rs
@@ -9,12 +9,16 @@ use serde_json::Value;
 pub struct CommentsData {
     pub total_awards_received: i32,
 <<<<<<< HEAD
+<<<<<<< HEAD
     pub approved_at_utc: Option<f64>,
     pub edited: bool,
     pub link_id: String,
     pub author_flair_template_id: Option<String>,
 =======
     pub approved_at_utc: i32,
+=======
+    pub approved_at_utc: Option<i32>,
+>>>>>>> fix more mistakes in CommentsData
     pub edited: bool,
     pub link_id: String,
     pub author_flair_template_id: String,

--- a/src/subreddit/responses/comments.rs
+++ b/src/subreddit/responses/comments.rs
@@ -40,7 +40,6 @@ pub struct CommentsData {
     pub archived: bool,
     pub no_follow: bool,
     pub author: String,
-    pub num_comments: i32,
     pub can_mod_post: bool,
     pub created_utc: f64,
     pub send_replies: bool,

--- a/src/subreddit/responses/comments.rs
+++ b/src/subreddit/responses/comments.rs
@@ -1,13 +1,17 @@
 use crate::responses::BasicListing;
 use serde::Deserialize;
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 use serde_json::Value;
 >>>>>>> Made the comment data accurate
+=======
+>>>>>>> Fixed CommentsData
 
 #[derive(Debug, Deserialize)]
 pub struct CommentsData {
     pub total_awards_received: i32,
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
     pub approved_at_utc: Option<f64>,
@@ -23,6 +27,12 @@ pub struct CommentsData {
     pub link_id: String,
     pub author_flair_template_id: String,
 >>>>>>> Made the comment data accurate
+=======
+    pub approved_at_utc: Option<f64>,
+    pub edited: bool,
+    pub link_id: String,
+    pub author_flair_template_id: Option<String>,
+>>>>>>> Fixed CommentsData
     pub likes: Option<bool>,
     pub saved: bool,
     pub id: String,
@@ -48,10 +58,14 @@ pub struct CommentsData {
     pub is_submitter: bool,
     pub body_html: String,
 <<<<<<< HEAD
+<<<<<<< HEAD
     pub distinguished: Option<String>,
 =======
     pub distinguished: Option<bool>,
 >>>>>>> fixed a few that I missed
+=======
+    pub distinguished: Option<String>,
+>>>>>>> Fixed CommentsData
     pub stickied: bool,
     pub author_premium: bool,
     pub can_gild: bool,

--- a/src/subreddit/responses/comments.rs
+++ b/src/subreddit/responses/comments.rs
@@ -1,13 +1,24 @@
 use crate::responses::BasicListing;
 use serde::Deserialize;
+<<<<<<< HEAD
+=======
+use serde_json::Value;
+>>>>>>> Made the comment data accurate
 
 #[derive(Debug, Deserialize)]
 pub struct CommentsData {
     pub total_awards_received: i32,
+<<<<<<< HEAD
     pub approved_at_utc: Option<f64>,
     pub edited: bool,
     pub link_id: String,
     pub author_flair_template_id: Option<String>,
+=======
+    pub approved_at_utc: i32,
+    pub edited: bool,
+    pub link_id: String,
+    pub author_flair_template_id: String,
+>>>>>>> Made the comment data accurate
     pub likes: Option<bool>,
     pub saved: bool,
     pub id: String,


### PR DESCRIPTION
This pull request adds me.private_message for sending a PM. For some reason it's trying to commit the latest_comments feature again but GitHub says it'll still merge right. I couldn't decide if this should be in me like posts are or in users, but I went with me because it already has the helper functions I need. If you want I can move it 

```
let client = Reddit::new(
    "USER_AGENT",
    "ID",
    "SECRET",
)
.username("USERNAME")
.password("PASSWORD")
.login();

let me = client.unwrap();
me.private_message("USERNAME", "title", "body").unwrap();
```