### PR TITLE
Add support for `message/unread`

### DIFF
--- a/src/me/mod.rs
+++ b/src/me/mod.rs
@@ -132,9 +132,16 @@ impl Me {
             .await?)
     }
 
+    /// Mark messages as read
     pub async fn mark_read(&self, ids: &str) -> Result<Response, RouxError> {
         let form = [("id", ids)];
         self.post("api/read_message", &form).await
+    }
+    
+    /// Mark messages as unread
+    pub async fn mark_read(&self, ids: &str) -> Result<Response, RouxError> {
+        let form = [("id", ids)];
+        self.post("api/unread_message", &form).await
     }
 
     pub async fn comment(&self, text: &str, parent: &str) -> Result<Response, RouxError> {

--- a/src/me/mod.rs
+++ b/src/me/mod.rs
@@ -139,7 +139,7 @@ impl Me {
     }
     
     /// Mark messages as unread
-    pub async fn mark_read(&self, ids: &str) -> Result<Response, RouxError> {
+    pub async fn mark_unread(&self, ids: &str) -> Result<Response, RouxError> {
         let form = [("id", ids)];
         self.post("api/unread_message", &form).await
     }

--- a/src/me/mod.rs
+++ b/src/me/mod.rs
@@ -123,6 +123,20 @@ impl Me {
             .await?)
     }
 
+    ///  Get users unread messages
+    pub async fn unread(&self) -> Result<BasicListing<InboxItem>, RouxError> {
+        Ok(self
+            .get("message/unread")
+            .await?
+            .json::<BasicListing<InboxItem>>()
+            .await?)
+    }
+
+    pub async fn mark_read(&self, ids: &str) -> Result<Response, RouxError> {
+        let form = [("id", ids)];
+        self.post("api/read_message", &form).await
+    }
+
     pub async fn comment(&self, text: &str, parent: &str) -> Result<Response, RouxError> {
         let form = [("text", text), ("parent", parent)];
         self.post("api/comment", &form).await


### PR DESCRIPTION
This PR fixes #12 

It adds support for 
`message/unread` : https://www.reddit.com/dev/api#GET_message_unread
`api/read_message` : https://www.reddit.com/dev/api#POST_api_read_message
`api/unread_message` : https://www.reddit.com/dev/api#POST_api_unread_message

