### PR TITLE
Make responses public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,19 +58,24 @@ use serde::Deserialize;
 use reqwest::header::USER_AGENT;
 use reqwest::Client;
 
+mod config;
+
 /// Subreddit module.
 pub mod subreddit;
 pub use subreddit::Subreddit;
+
 /// User module.
 pub mod user;
 pub use user::User;
 
-mod config;
-mod me;
-mod responses;
+/// Me module.
+pub mod me;
+pub use me::Me;
+
+pub mod responses;
+
 /// Utils for requests.
 pub mod util;
-
 use util::url;
 
 /// Client to use OAuth with Reddit.

--- a/src/me/mod.rs
+++ b/src/me/mod.rs
@@ -1,3 +1,6 @@
+//! # Me
+//! Me module.
+
 extern crate reqwest;
 extern crate serde_json;
 
@@ -8,17 +11,20 @@ use crate::config::Config;
 use crate::responses::BasicListing;
 use crate::util::{url, RouxError};
 
-mod responses;
+pub mod responses;
 use responses::InboxItem;
 use responses::MeData;
 
+/// Me
 pub struct Me {
+    /// Access token
     pub access_token: String,
     client: Client,
     config: Config,
 }
 
 impl Me {
+    /// Create a new `me`
     pub fn new(access_token: &str, config: Config) -> Me {
         let mut headers = header::HeaderMap::new();
 
@@ -36,12 +42,12 @@ impl Me {
 
         Me {
             access_token: access_token.to_owned(),
-            config: config,
-            client: client,
+            config,
+            client,
         }
     }
 
-    pub async fn get(&self, url: &str) -> Result<Response, RouxError> {
+    async fn get(&self, url: &str) -> Result<Response, RouxError> {
         let get_url = url::build_oauth(url);
 
         match self.client.get(&get_url[..]).send().await {
@@ -50,14 +56,7 @@ impl Me {
         }
     }
 
-    pub async fn me(&self) -> Result<MeData, RouxError> {
-        match self.get("api/v1/me").await {
-            Ok(res) => Ok(res.json::<MeData>().await?),
-            Err(e) => Err(e.into()),
-        }
-    }
-
-    pub async fn post<T: Serialize>(&self, url: &str, form: T) -> Result<Response, RouxError> {
+    async fn post<T: Serialize>(&self, url: &str, form: T) -> Result<Response, RouxError> {
         let post_url = url::build_oauth(url).to_owned();
 
         match self.client.post(&post_url[..]).form(&form).send().await {
@@ -66,6 +65,15 @@ impl Me {
         }
     }
 
+    /// Get me
+    pub async fn me(&self) -> Result<MeData, RouxError> {
+        match self.get("api/v1/me").await {
+            Ok(res) => Ok(res.json::<MeData>().await?),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Submit link
     pub async fn submit_link(
         &self,
         title: &str,
@@ -82,6 +90,7 @@ impl Me {
         self.post("api/submit", &form).await
     }
 
+    /// Submit text
     pub async fn submit_text(
         &self,
         title: &str,
@@ -98,6 +107,7 @@ impl Me {
         self.post("api/submit", &form).await
     }
 
+    /// Compose message
     pub async fn compose_message(
         &self,
         username: &str,
@@ -114,7 +124,7 @@ impl Me {
         self.post("api/compose", &form).await
     }
 
-    // Get user's submitted posts.
+    /// Get user's submitted posts.
     pub async fn inbox(&self) -> Result<BasicListing<InboxItem>, RouxError> {
         Ok(self
             .get("message/inbox")
@@ -123,7 +133,7 @@ impl Me {
             .await?)
     }
 
-    ///  Get users unread messages
+    /// Get users unread messages
     pub async fn unread(&self) -> Result<BasicListing<InboxItem>, RouxError> {
         Ok(self
             .get("message/unread")
@@ -137,23 +147,26 @@ impl Me {
         let form = [("id", ids)];
         self.post("api/read_message", &form).await
     }
-    
+
     /// Mark messages as unread
     pub async fn mark_unread(&self, ids: &str) -> Result<Response, RouxError> {
         let form = [("id", ids)];
         self.post("api/unread_message", &form).await
     }
 
+    /// Comment
     pub async fn comment(&self, text: &str, parent: &str) -> Result<Response, RouxError> {
         let form = [("text", text), ("parent", parent)];
         self.post("api/comment", &form).await
     }
 
+    /// Edit
     pub async fn edit(&self, text: &str, parent: &str) -> Result<Response, RouxError> {
         let form = [("text", text), ("thing_id", parent)];
         self.post("api/editusertext", &form).await
     }
 
+    /// Logout
     pub async fn logout(self) -> Result<(), RouxError> {
         let url = "https://www.reddit.com/api/v1/revoke_token";
 

--- a/src/me/mod.rs
+++ b/src/me/mod.rs
@@ -12,7 +12,7 @@ use crate::responses::BasicListing;
 use crate::util::{url, RouxError};
 
 pub mod responses;
-use responses::InboxItem;
+use responses::Inbox;
 use responses::MeData;
 
 /// Me
@@ -125,7 +125,7 @@ impl Me {
     }
 
     /// Get user's submitted posts.
-    pub async fn inbox(&self) -> Result<BasicListing<InboxItem>, RouxError> {
+    pub async fn inbox(&self) -> Result<Inbox, RouxError> {
         Ok(self
             .get("message/inbox")
             .await?
@@ -134,7 +134,7 @@ impl Me {
     }
 
     /// Get users unread messages
-    pub async fn unread(&self) -> Result<BasicListing<InboxItem>, RouxError> {
+    pub async fn unread(&self) -> Result<Inbox, RouxError> {
         Ok(self
             .get("message/unread")
             .await?

--- a/src/me/mod.rs
+++ b/src/me/mod.rs
@@ -8,12 +8,10 @@ use reqwest::{header, Client, Response};
 use serde::Serialize;
 
 use crate::config::Config;
-use crate::responses::BasicListing;
 use crate::util::{url, RouxError};
 
 pub mod responses;
-use responses::Inbox;
-use responses::MeData;
+use responses::{MeData, Inbox};
 
 /// Me
 pub struct Me {
@@ -129,7 +127,7 @@ impl Me {
         Ok(self
             .get("message/inbox")
             .await?
-            .json::<BasicListing<InboxItem>>()
+            .json::<Inbox>()
             .await?)
     }
 
@@ -138,7 +136,7 @@ impl Me {
         Ok(self
             .get("message/unread")
             .await?
-            .json::<BasicListing<InboxItem>>()
+            .json::<Inbox>()
             .await?)
     }
 

--- a/src/me/responses/inbox.rs
+++ b/src/me/responses/inbox.rs
@@ -1,0 +1,42 @@
+//! # Inbox Reponses
+use serde::Deserialize;
+
+use crate::responses::BasicListing;
+
+/// InboxItem
+#[derive(Debug, Deserialize)]
+pub struct InboxData {
+    /// ID
+    pub id: String,
+    /// Subject
+    pub subject: String,
+    /// Was comment
+    pub was_comment: bool,
+    /// Author
+    pub author: Option<String>,
+    /// Parent ID
+    pub parent_id: Option<String>,
+    /// Sub name
+    pub subreddit_name_prefixed: Option<String>,
+    /// New
+    pub new: bool,
+    /// ???
+    pub r#type: String,
+    /// Body
+    pub body: String,
+    /// Dest
+    pub dest: String,
+    /// Body HTML
+    pub body_html: String,
+    /// Name
+    pub name: String,
+    /// Created
+    pub created: f64,
+    /// Created (UTC)
+    pub created_utc: f64,
+    /// Context
+    pub context: String,
+}
+
+/// Inbox
+pub type Inbox = BasicListing<InboxData>;

--- a/src/me/responses/me.rs
+++ b/src/me/responses/me.rs
@@ -1,4 +1,4 @@
-//! # MeData Responses
+//! # Me Responses
 use serde::Deserialize;
 
 /// MeData
@@ -36,39 +36,4 @@ pub struct MeData {
     pub is_gold: bool,
     /// Icon img
     pub icon_img: String,
-}
-
-/// InboxItem
-#[derive(Debug, Deserialize)]
-pub struct InboxItem {
-    /// ID
-    pub id: String,
-    /// Subject
-    pub subject: String,
-    /// Was comment
-    pub was_comment: bool,
-    /// Author
-    pub author: Option<String>,
-    /// Parent ID
-    pub parent_id: Option<String>,
-    /// Sub name
-    pub subreddit_name_prefixed: Option<String>,
-    /// New
-    pub new: bool,
-    /// ???
-    pub r#type: String,
-    /// Body
-    pub body: String,
-    /// Dest
-    pub dest: String,
-    /// Body HTML
-    pub body_html: String,
-    /// Name
-    pub name: String,
-    /// Created
-    pub created: f64,
-    /// Created (UTC)
-    pub created_utc: f64,
-    /// Context
-    pub context: String,
 }

--- a/src/me/responses/me.rs
+++ b/src/me/responses/me.rs
@@ -1,40 +1,74 @@
+//! # MeData Responses
 use serde::Deserialize;
 
+/// MeData
 #[derive(Debug, Deserialize)]
 pub struct MeData {
+    /// ID
     pub id: String,
+    /// Is employee
     pub is_employee: bool,
+    /// Verified
     pub verified: bool,
+    /// Over 18
     pub over_18: bool,
+    /// Has verified email
     pub has_verified_email: bool,
+    /// Is suspended
     pub is_suspended: bool,
+    /// Has mail
     pub has_mail: bool,
+    /// Inbox count
     pub inbox_count: f64,
+    /// Created
     pub created: f64,
+    /// Created (UTC)
     pub created_utc: f64,
+    /// In beta
     pub in_beta: bool,
+    /// Comment karma
     pub comment_karma: i32,
+    /// Link karma
     pub link_karma: i32,
+    /// Is mod
     pub is_mod: bool,
+    /// Is gold
     pub is_gold: bool,
+    /// Icon img
     pub icon_img: String,
 }
 
+/// InboxItem
 #[derive(Debug, Deserialize)]
 pub struct InboxItem {
+    /// ID
     pub id: String,
+    /// Subject
     pub subject: String,
+    /// Was comment
     pub was_comment: bool,
+    /// Author
     pub author: Option<String>,
+    /// Parent ID
     pub parent_id: Option<String>,
+    /// Sub name
     pub subreddit_name_prefixed: Option<String>,
+    /// New
     pub new: bool,
+    /// ???
     pub r#type: String,
+    /// Body
     pub body: String,
+    /// Dest
     pub dest: String,
+    /// Body HTML
     pub body_html: String,
+    /// Name
     pub name: String,
+    /// Created
     pub created: f64,
+    /// Created (UTC)
     pub created_utc: f64,
+    /// Context
     pub context: String,
 }

--- a/src/me/responses/mod.rs
+++ b/src/me/responses/mod.rs
@@ -1,3 +1,4 @@
+//! # Me Responses
 pub mod me;
 pub use me::InboxItem;
 pub use me::MeData;

--- a/src/me/responses/mod.rs
+++ b/src/me/responses/mod.rs
@@ -1,4 +1,6 @@
 //! # Me Responses
 pub mod me;
-pub use me::InboxItem;
 pub use me::MeData;
+
+pub mod inbox;
+pub use inbox::{Inbox, InboxData};

--- a/src/responses/mod.rs
+++ b/src/responses/mod.rs
@@ -1,3 +1,6 @@
+//! # Responses
+//! Base responses
+
 use serde::Deserialize;
 
 /// Basic structure of a Reddit response.

--- a/src/subreddit/mod.rs
+++ b/src/subreddit/mod.rs
@@ -45,7 +45,7 @@ extern crate serde_json;
 use crate::util::{FeedOption, RouxError};
 use reqwest::Client;
 
-mod responses;
+pub mod responses;
 use responses::{Comments, Moderators, Submissions};
 
 /// Subreddit.

--- a/src/subreddit/mod.rs
+++ b/src/subreddit/mod.rs
@@ -46,7 +46,7 @@ use crate::util::{FeedOption, RouxError};
 use reqwest::Client;
 
 pub mod responses;
-use responses::{Comments, Moderators, Submissions};
+use responses::{SubredditComments, Moderators, Submissions};
 
 /// Subreddit.
 pub struct Subreddit {
@@ -118,7 +118,7 @@ impl Subreddit {
         ty: &str,
         depth: Option<u32>,
         limit: Option<u32>,
-    ) -> Result<Comments, RouxError> {
+    ) -> Result<SubredditComments, RouxError> {
         let url = &mut format!("{}/{}.json?", self.url, ty);
 
         if !depth.is_none() {
@@ -139,7 +139,7 @@ impl Subreddit {
                 .get(&url.to_owned())
                 .send()
                 .await?
-                .json::<Vec<Comments>>()
+                .json::<Vec<SubredditComments>>()
                 .await?;
 
             Ok(comments.pop().unwrap())
@@ -149,7 +149,7 @@ impl Subreddit {
                 .get(&url.to_owned())
                 .send()
                 .await?
-                .json::<Comments>()
+                .json::<SubredditComments>()
                 .await?)
         }
     }
@@ -196,7 +196,7 @@ impl Subreddit {
         &self,
         depth: Option<u32>,
         limit: Option<u32>,
-    ) -> Result<Comments, RouxError> {
+    ) -> Result<SubredditComments, RouxError> {
         self.get_comment_feed("comments", depth, limit).await
     }
 
@@ -206,7 +206,7 @@ impl Subreddit {
         article: &str,
         depth: Option<u32>,
         limit: Option<u32>,
-    ) -> Result<Comments, RouxError> {
+    ) -> Result<SubredditComments, RouxError> {
         self.get_comment_feed(&format!("comments/{}", article), depth, limit)
             .await
     }

--- a/src/subreddit/responses/comments.rs
+++ b/src/subreddit/responses/comments.rs
@@ -1,57 +1,108 @@
+//! # Subreddit Comment Responses
 use crate::responses::BasicListing;
 use serde::Deserialize;
 
-// Everything is an option to deal with both `latest_comments` and `article_comments`
+/// CommentsData
+/// Everything is an option to deal with both `latest_comments` and `article_comments`
 #[derive(Debug, Deserialize)]
 pub struct CommentsData {
+    /// Total awards
     pub total_awards_received: Option<i32>,
+    /// Approved at (UTC)
     pub approved_at_utc: Option<f64>,
+    /// Link id
     pub link_id: Option<String>,
+    /// What is this
     pub author_flair_template_id: Option<String>,
+    /// Likes
     pub likes: Option<bool>,
+    /// Saved
     pub saved: Option<bool>,
+    /// ID
     pub id: Option<String>,
+    /// Gilded
     pub gilded: Option<i32>,
+    /// Archived
     pub archived: Option<bool>,
+    /// No follow
     pub no_follow: Option<bool>,
+    /// Auuthor
     pub author: Option<String>,
+    /// Can mod post
     pub can_mod_post: Option<bool>,
+    /// Created (UTC)
     pub created_utc: Option<f64>,
+    /// Send replies
     pub send_replies: Option<bool>,
+    /// Parent ID
     pub parent_id: Option<String>,
+    /// Score
     pub score: Option<i32>,
+    /// Author fullname
     pub author_fullname: Option<String>,
+    /// Over 18
     pub over_18: Option<bool>,
+    /// Approved by
     pub approved_by: Option<String>,
+    /// Subreddit ID
     pub subreddit_id: Option<String>,
+    /// Body
     pub body: Option<String>,
+    /// Link title
     pub link_title: Option<String>,
+    /// Name
     pub name: Option<String>,
+    /// Patreon flair
     pub author_patreon_flair: Option<bool>,
+    /// Downs?
     pub downs: Option<i32>,
+    /// Is submitter
     pub is_submitter: Option<bool>,
+    /// HTML
     pub body_html: Option<String>,
+    /// Distinguished
     pub distinguished: Option<String>,
+    /// Stickied
     pub stickied: Option<bool>,
+    /// Premium
     pub author_premium: Option<bool>,
+    /// Can guild
     pub can_gild: Option<bool>,
+    /// Subreddit
     pub subreddit: Option<String>,
+    /// Flair color
     pub author_flair_text_color: Option<String>,
+    /// Score hidden
     pub score_hidden: Option<bool>,
+    /// Permalink
     pub permalink: Option<String>,
+    /// Number of reports
     pub num_reports: Option<i32>,
+    /// Permalink
     pub link_permalink: Option<String>,
+    /// Author link
     pub link_author: Option<String>,
+    /// Sub name
     pub subreddit_name_prefixed: Option<String>,
+    /// Author flair
     pub author_flair_text: Option<String>,
+    /// Link url
     pub link_url: Option<String>,
+    /// Created
     pub created: Option<f64>,
+    /// Collapsed
     pub collapsed: Option<bool>,
+    /// Controversiality
     pub controversiality: Option<i32>,
+    /// Locked
     pub locked: Option<bool>,
+    /// Quarantine
     pub quarantine: Option<bool>,
+    /// Subreddit type
     pub subreddit_type: Option<String>,
+    /// UPS?
     pub ups: Option<i32>,
 }
 
+/// Comments
 pub type Comments = BasicListing<CommentsData>;

--- a/src/subreddit/responses/comments.rs
+++ b/src/subreddit/responses/comments.rs
@@ -2,10 +2,10 @@
 use crate::responses::BasicListing;
 use serde::Deserialize;
 
-/// CommentsData
+/// SubredditCommentsData
 /// Everything is an option to deal with both `latest_comments` and `article_comments`
 #[derive(Debug, Deserialize)]
-pub struct CommentsData {
+pub struct SubredditCommentsData {
     /// Total awards
     pub total_awards_received: Option<i32>,
     /// Approved at (UTC)
@@ -104,5 +104,5 @@ pub struct CommentsData {
     pub ups: Option<i32>,
 }
 
-/// Comments
-pub type Comments = BasicListing<CommentsData>;
+/// SubredditComments
+pub type SubredditComments = BasicListing<SubredditCommentsData>;

--- a/src/subreddit/responses/mod.rs
+++ b/src/subreddit/responses/mod.rs
@@ -1,3 +1,4 @@
+//! # Subreddit Responses
 pub mod moderators;
 pub use moderators::Moderators;
 

--- a/src/subreddit/responses/mod.rs
+++ b/src/subreddit/responses/mod.rs
@@ -1,9 +1,9 @@
 //! # Subreddit Responses
 pub mod moderators;
-pub use moderators::Moderators;
+pub use moderators::{Moderators, ModeratorsData};
 
 pub mod submissions;
-pub use submissions::Submissions;
+pub use submissions::{Submissions, SubmissionsData};
 
 pub mod comments;
-pub use comments::Comments;
+pub use comments::{SubredditComments, SubredditCommentsData};

--- a/src/subreddit/responses/moderators.rs
+++ b/src/subreddit/responses/moderators.rs
@@ -1,13 +1,17 @@
+//! # Subreddit Moderator Responses
 use crate::responses::{BasicThing, Listing};
 use serde::Deserialize;
 
+/// ModeratorsData
 #[derive(Debug, Deserialize)]
 pub struct ModeratorsData {
     /// The ID of the moderator
     pub id: String,
     /// The name of the moderator
     pub name: String,
+    /// Author flair text
     pub author_flair_text: Option<String>,
 }
 
+/// Moderators
 pub type Moderators = BasicThing<Listing<ModeratorsData>>;

--- a/src/subreddit/responses/submissions.rs
+++ b/src/subreddit/responses/submissions.rs
@@ -1,7 +1,9 @@
+//! # Subreddit Submussion Responses
 use crate::responses::BasicListing;
 use serde::Deserialize;
 use serde_json::Value;
 
+/// SubmissionsData
 #[derive(Debug, Deserialize)]
 pub struct SubmissionsData {
     /// The domain of the link (if link post) or self.subreddit (if self post).
@@ -123,11 +125,13 @@ pub struct SubmissionsData {
     pub title: String,
     /// A timestamp of the time when the post was created, in **UTC**.
     pub created_utc: f64,
+    /// Distinguished
     pub distinguished: Option<String>,
-    // This is `true` if the user has visited this link.
+    /// This is `true` if the user has visited this link.
     pub visited: bool,
-    // The number of reports, if the user is a moderator of this subreddit.
+    /// The number of reports, if the user is a moderator of this subreddit.
     pub num_reports: Option<u64>,
 }
 
+/// Submissions
 pub type Submissions = BasicListing<SubmissionsData>;

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -21,7 +21,7 @@ use crate::util::RouxError;
 use reqwest::Client;
 
 pub mod responses;
-use responses::{Comments, Overview, Submitted};
+use responses::{UserComments, Overview, Submitted};
 
 /// User.
 pub struct User {
@@ -68,7 +68,7 @@ impl User {
     }
 
     /// Get user's submitted comments.
-    pub async fn comments(&self) -> Result<Comments, RouxError> {
+    pub async fn comments(&self) -> Result<UserComments, RouxError> {
         Ok(self
             .client
             .get(&format!(
@@ -77,7 +77,7 @@ impl User {
             ))
             .send()
             .await?
-            .json::<Comments>()
+            .json::<UserComments>()
             .await?)
     }
 }

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -20,7 +20,7 @@ extern crate serde_json;
 use crate::util::RouxError;
 use reqwest::Client;
 
-mod responses;
+pub mod responses;
 use responses::{Comments, Overview, Submitted};
 
 /// User.

--- a/src/user/responses/comments.rs
+++ b/src/user/responses/comments.rs
@@ -1,14 +1,23 @@
+//! # User Comment Responses
 use crate::responses::BasicListing;
 use serde::Deserialize;
 
+/// CommentsData
 #[derive(Debug, Deserialize)]
 pub struct CommentsData {
+    /// Body
     pub body: String,
+    /// Body HTML
     pub body_html: String,
+    /// Link title
     pub link_title: String,
+    /// Link url
     pub link_url: String,
+    /// Subreddit
     pub subreddit: String,
+    /// Created
     pub created: f64,
 }
 
+/// Comments
 pub type Comments = BasicListing<CommentsData>;

--- a/src/user/responses/comments.rs
+++ b/src/user/responses/comments.rs
@@ -2,9 +2,9 @@
 use crate::responses::BasicListing;
 use serde::Deserialize;
 
-/// CommentsData
+/// UserCommentsData
 #[derive(Debug, Deserialize)]
-pub struct CommentsData {
+pub struct UserCommentsData {
     /// Body
     pub body: String,
     /// Body HTML
@@ -19,5 +19,5 @@ pub struct CommentsData {
     pub created: f64,
 }
 
-/// Comments
-pub type Comments = BasicListing<CommentsData>;
+/// UserComments
+pub type UserComments = BasicListing<UserCommentsData>;

--- a/src/user/responses/mod.rs
+++ b/src/user/responses/mod.rs
@@ -1,3 +1,4 @@
+//! User responses
 pub mod overview;
 pub use overview::Overview;
 

--- a/src/user/responses/mod.rs
+++ b/src/user/responses/mod.rs
@@ -1,9 +1,9 @@
-//! User responses
+//! # User responses
 pub mod overview;
-pub use overview::Overview;
+pub use overview::{Overview, OverviewData};
 
 pub mod submitted;
-pub use submitted::Submitted;
+pub use submitted::{Submitted, SubmittedData};
 
 pub mod comments;
-pub use comments::Comments;
+pub use comments::{UserComments, UserCommentsData};

--- a/src/user/responses/overview.rs
+++ b/src/user/responses/overview.rs
@@ -1,19 +1,30 @@
+//! # User Overview Responses
 use crate::{responses::BasicListing, util::defaults::default_string};
 use serde::Deserialize;
 
+/// OverviewData
 #[derive(Debug, Deserialize)]
 pub struct OverviewData {
+    /// Author
     pub author: String,
+    /// Likes
     pub likes: Option<i32>,
+    /// Score
     pub score: i32,
+    /// Subreddit
     pub subreddit: String,
+    /// Created
     pub created: f64,
+    /// Body
     #[serde(default = "default_string")]
     pub body: String,
+    /// Link title
     #[serde(default = "default_string")]
     pub link_title: String,
+    /// Link url
     #[serde(default = "default_string")]
     pub link_url: String,
 }
 
+/// Overview
 pub type Overview = BasicListing<OverviewData>;

--- a/src/user/responses/submitted.rs
+++ b/src/user/responses/submitted.rs
@@ -1,15 +1,25 @@
+//! # User Submitted Responses
 use crate::responses::BasicListing;
 use serde::Deserialize;
 
+/// Submitted
 #[derive(Debug, Deserialize)]
 pub struct SubmittedData {
+    /// Subreddit
     pub subreddit: String,
+    /// Title
     pub title: String,
+    /// Thumbnail
     pub thumbnail: String,
+    /// Score
     pub score: i32,
+    /// Created
     pub created: f64,
+    /// Domain
     pub domain: String,
+    /// Is self
     pub is_self: bool,
 }
 
+/// Submitted
 pub type Submitted = BasicListing<SubmittedData>;


### PR DESCRIPTION
Makes responses public for issue #14.

You can import them with:

```rust
use roux::subreddit::responses::{Moderators, Submissions}
use roux::me::responses::MeData;
use roux::responses::BasicListing;
```